### PR TITLE
feat: add a progress bar for the image progress

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,6 +102,8 @@ function App() {
               <a
                 href="https://github.com/lxfater/inpaint-web"
                 style={{ color: 'blue' }}
+                rel="noreferrer"
+                target="_blank"
               >
                 Inpaint-web
               </a>{' '}
@@ -113,6 +115,8 @@ function App() {
               <a
                 href="https://github.com/lxfater/inpaint-web"
                 style={{ color: 'blue' }}
+                rel="noreferrer"
+                target="_blank"
               >
                 Inpaint-web
               </a>{' '}


### PR DESCRIPTION
- add a progress bar for the image progress
- replacing the open mode of the external link in the feedback

<img width="1466" alt="image" src="https://github.com/lxfater/inpaint-web/assets/42437658/d40074f7-a242-4e2c-952b-a66805e19758">
