### PR TITLE
feat: add a brush size preview when changing brush size

### DIFF
--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -6,10 +6,11 @@ type SliderProps = {
   min?: number
   max?: number
   onChange: (value: number) => void
+  onStart?: () => void
 }
 
 export default function Slider(props: SliderProps) {
-  const { value, onChange, label, min, max } = props
+  const { value, label, min, max, onChange, onStart } = props
 
   const step = ((max || 100) - (min || 0)) / 100
 
@@ -23,6 +24,7 @@ export default function Slider(props: SliderProps) {
         min={min}
         max={max}
         value={value}
+        onPointerDown={onStart}
         onChange={ev => {
           ev.preventDefault()
           ev.stopPropagation()


### PR DESCRIPTION
在改变笔刷大小的时候新增预览，因为在微调时会经常改变笔刷大小，增加`笔刷预览`可以增强微调体验。
![image](https://github.com/lxfater/inpaint-web/assets/3118553/663c4d43-d973-4793-8c3a-ad7ac8f1809f)
