### PR TITLE
fix: use constant variable to replace react state varible to fix infi…

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -62,7 +62,6 @@ export default function Editor(props: EditorProps) {
   const [isInpaintingLoading, setIsInpaintingLoading] = useState(false)
   const [scale, setScale] = useState(1)
   const [generateProgress, setGenerateProgress] = useState(0)
-  const [timer, setTimer] = useState(0)
   const modalRef = useRef(null)
   const [separator, setSeparator] = useState<HTMLDivElement>()
   const [useSeparator, setUseSeparator] = useState(false)
@@ -151,16 +150,14 @@ export default function Editor(props: EditorProps) {
       }
       setIsInpaintingLoading(true)
       setGenerateProgress(0)
-      setTimer(
-        window.setInterval(() => {
-          setGenerateProgress(p => {
-            if (p < 90) return p + 10 * Math.random()
-            if (p >= 90 && p < 99) return p + 1 * Math.random()
-            window.setTimeout(() => setIsInpaintingLoading(false), 500)
-            return p
-          })
-        }, 1000)
-      )
+      const progressTimer = window.setInterval(() => {
+        setGenerateProgress(p => {
+          if (p < 90) return p + 10 * Math.random()
+          if (p >= 90 && p < 99) return p + 1 * Math.random()
+          window.setTimeout(() => setIsInpaintingLoading(false), 500)
+          return p
+        })
+      }, 1000)
 
       canvas.removeEventListener('mousemove', onMouseDrag)
       window.removeEventListener('mouseup', onPointerUp)
@@ -194,7 +191,7 @@ export default function Editor(props: EditorProps) {
       }
 
       setGenerateProgress(100)
-      if (timer) clearInterval(timer)
+      if (progressTimer) window.clearInterval(progressTimer)
       historyListRef.current?.scrollTo(historyListRef.current.offsetWidth, 0)
       setIsInpaintingLoading(false)
       draw()


### PR DESCRIPTION
Cause react setState won't change the state immediately,the old progress timmer state won't clear correctly,and the `setGenerateProgress` function will execute forever.It's no need to use state varible,all we need is a constant variable to save the progress interval timer.
![微信截图_20231124180337](https://github.com/lxfater/inpaint-web/assets/3118553/69ee814a-eac8-481b-a80a-91909613de2d)
![微信截图_20231124180232](https://github.com/lxfater/inpaint-web/assets/3118553/720c6d73-f5d1-4b4e-becf-06097c9b86df)
