### PR TITLE
fix: bursh size is reset when drawing & history overflow cannot be scrolled completely

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -68,6 +68,7 @@ export default function Editor(props: EditorProps) {
   const [originalImg, setOriginalImg] = useState<HTMLDivElement>()
   const [separatorLeft, setSeparatorLeft] = useState(0)
   const historyListRef = useRef<HTMLDivElement>(null)
+  const isBrushSizeChange = useRef<boolean>(false)
 
   const windowSize = useWindowSize()
 
@@ -113,7 +114,9 @@ export default function Editor(props: EditorProps) {
         console.log(Math.min(rW, rH))
         const newScale = Math.min(rW, rH)
         setScale(newScale)
-        setBrushSize(40 / newScale)
+        if (!isBrushSizeChange.current) {
+          setBrushSize(40 / newScale)
+        }
       } else {
         setScale(1)
       }
@@ -412,6 +415,9 @@ export default function Editor(props: EditorProps) {
     })
   }
   const handleSliderChange = (sliderValue: number) => {
+    if (!isBrushSizeChange.current) {
+      isBrushSizeChange.current = true
+    }
     setBrushSize(sliderValue)
     window.clearTimeout(hideBrushTimeout)
     setHideBrushTimeout(

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -192,7 +192,12 @@ export default function Editor(props: EditorProps) {
 
       setGenerateProgress(100)
       if (progressTimer) window.clearInterval(progressTimer)
-      historyListRef.current?.scrollTo(historyListRef.current.offsetWidth, 0)
+      if (historyListRef.current) {
+        const { scrollWidth, clientWidth } = historyListRef.current
+        if (scrollWidth > clientWidth) {
+          historyListRef.current.scrollTo(scrollWidth, 0)
+        }
+      }
       setIsInpaintingLoading(false)
       draw()
     }
@@ -427,9 +432,9 @@ export default function Editor(props: EditorProps) {
         ref={historyListRef}
         className={[
           'flex items-left w-full max-w-4xl py-0',
-          'flex-col space-y-2 sm:space-y-0 sm:flex-row sm:space-x-5 overflow-auto pb-1',
-          'scrollbar-thin scrollbar-thumb-black scrollbar-track-primary scrollbar-rounded-lg overflow-x-scroll',
-          scale !== 1 ? 'absolute top-0 justify-center' : 'relative',
+          'flex-col space-y-2 sm:space-y-0 sm:flex-row sm:space-x-5 pb-1',
+          'scrollbar-thin scrollbar-thumb-black scrollbar-track-primary overflow-x-scroll',
+          scale !== 1 ? 'absolute top-0' : 'relative',
         ].join(' ')}
       >
         {History}


### PR DESCRIPTION
修复绘制之后画笔大小被重置&历史队列无法滚动全 