### PR TITLE
Improve high resolution inpainting when used with small or small-incremental masks

### DIFF
--- a/src/adapters/cache.ts
+++ b/src/adapters/cache.ts
@@ -9,8 +9,12 @@ const modelList = [
     name: 'model-perf',
     url: 'https://huggingface.co/andraniksargsyan/migan/resolve/main/migan.onnx',
   },
+  {
+    name: 'migan-pipeline-v2',
+    url: 'https://huggingface.co/andraniksargsyan/migan/resolve/main/migan_pipeline_v2.onnx',
+  },
 ]
-const currentModel = modelList[1]
+const currentModel = modelList[2]
 const key = currentModel.name
 const { url } = currentModel
 localforage.config({

--- a/src/adapters/use_download.ts
+++ b/src/adapters/use_download.ts
@@ -27,7 +27,7 @@ const useDownload = () => {
       setDownloadProgress(0)
 
       const response = await fetch(
-        'https://huggingface.co/andraniksargsyan/migan/resolve/main/migan.onnx'
+        'https://huggingface.co/andraniksargsyan/migan/resolve/main/migan_pipeline_v2.onnx'
       )
       const fullSize = response.headers.get('content-length')
       const reader = response.body!.getReader()


### PR DESCRIPTION
I have modified MI-GAN ONNX Pipeline in order to crop the image and mask around the masked region and then inpaint. With this, and with [this issue](https://github.com/lxfater/inpaint-web/issues/33) already solved, we can have better high-resolution image inpainting. Below you can see three attached examples inpainted before and after the fix.

Please note, that when inpainting high resolution images with large masks, one may get better results by incremental inpainting (i.e. inpainting with smaller brush strokes instead of creating a single large one). Below results are generated with such approach.


Original image:
<img width="1764" alt="test" src="https://github.com/lxfater/inpaint-web/assets/8330396/e35a3d0d-09e8-4dd1-9a72-90a0e9b213eb">

Before fix:
![test_before_fix](https://github.com/lxfater/inpaint-web/assets/8330396/e6fec99f-93fe-4f10-8933-02ad126223f7)

After fix:
![test_with_fix](https://github.com/lxfater/inpaint-web/assets/8330396/d9fd8ae4-8b08-4c65-9ed7-ca4f2adcabf9)


Original image:
![paris](https://github.com/lxfater/inpaint-web/assets/8330396/42451ad6-7d3c-41fe-9717-d52c8868cce8)

Before fix:
![paris_before_fix](https://github.com/lxfater/inpaint-web/assets/8330396/e235d48e-f6e3-4edd-bedd-3bd8c1db589a)

After fix:
![paris_after_fix](https://github.com/lxfater/inpaint-web/assets/8330396/cac7c337-5484-44b5-b863-c70ee01d3a36)

Original image:
![nature](https://github.com/lxfater/inpaint-web/assets/8330396/a45dc511-c8e6-487d-8603-15631037b72f)

Before fix:
![nature_before_fix](https://github.com/lxfater/inpaint-web/assets/8330396/8a5d7e63-a5d6-452f-9425-953c2c4e4c6a)

After fix:
![nature_after_fix](https://github.com/lxfater/inpaint-web/assets/8330396/6c17f33f-d309-4b4e-833e-076e63e48cb8)
