### PR TITLE
call configEnv() only when model is not created, and reuse capabilities.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
     "airbnb/hooks",
     "plugin:@typescript-eslint/recommended",
     "prettier",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:react/jsx-runtime"
   ],
   "plugins": ["@typescript-eslint", "react", "react-hooks", "prettier"],
   "parser": "@typescript-eslint/parser",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import { ArrowLeftIcon, InformationCircleIcon } from '@heroicons/react/outline'
-import React, { useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { useClickAway } from 'react-use'
 import Button from './components/Button'
 import FileSelect from './components/FileSelect'

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import { DownloadIcon, EyeIcon, ViewBoardsIcon } from '@heroicons/react/outline'
-import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react'
+import { useCallback, useEffect, useState, useRef, useMemo } from 'react'
 import { useWindowSize } from 'react-use'
 import inpaint from './adapters/inpainting'
 import Button from './components/Button'

--- a/src/adapters/inpainting.ts
+++ b/src/adapters/inpainting.ts
@@ -149,17 +149,16 @@ function imageDataToDataURL(imageData) {
   return canvas.toDataURL()
 }
 
-async function configEnv() {
-  const capablilities = await getCapabilities()
+function configEnv(capabilities) {
   ort.env.wasm.wasmPaths =
     'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.16.3/dist/'
-  if (capablilities.webgpu) {
+  if (capabilities.webgpu) {
     ort.env.wasm.numThreads = 1
   } else {
-    if (capablilities.threads) {
+    if (capabilities.threads) {
       ort.env.wasm.numThreads = navigator.hardwareConcurrency ?? 4
     }
-    if (capablilities.simd) {
+    if (capabilities.simd) {
       ort.env.wasm.simd = true
     }
     ort.env.wasm.proxy = true
@@ -172,13 +171,13 @@ export default async function inpaint(
   imageFile: File | HTMLImageElement,
   maskBase64: string
 ) {
-  await configEnv()
   console.time('sessionCreate')
   if (!model) {
-    const capablilities = await getCapabilities()
+    const capabilities = await getCapabilities()
+    configEnv(capabilities)
     const modelBuffer = await ensureModel()
     model = await ort.InferenceSession.create(modelBuffer, {
-      executionProviders: [capablilities.webgpu ? 'webgpu' : 'wasm'],
+      executionProviders: [capabilities.webgpu ? 'webgpu' : 'wasm'],
     })
   }
   console.timeEnd('sessionCreate')

--- a/src/adapters/inpainting.ts
+++ b/src/adapters/inpainting.ts
@@ -182,17 +182,12 @@ export default async function inpaint(
   }
   console.timeEnd('sessionCreate')
   console.time('preProcess')
-  let imgDom = null
-  if (imageFile instanceof HTMLImageElement) {
-    imgDom = imageFile
-  } else {
-    imgDom = loadImage(URL.createObjectURL(imageFile))
-  }
-  const markUrl = maskBase64
 
   const [originalImg, originalMark] = await Promise.all([
-    imgDom,
-    loadImage(markUrl),
+    imageFile instanceof HTMLImageElement
+      ? imageFile
+      : loadImage(URL.createObjectURL(imageFile)),
+    loadImage(maskBase64),
   ])
 
   const [img, mark] = await Promise.all([

--- a/src/adapters/use_download.ts
+++ b/src/adapters/use_download.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { modelExists, saveModel } from './cache'
 
 const useDownload = () => {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 interface ButtonProps {
   children: ReactNode

--- a/src/components/FileSelect.tsx
+++ b/src/components/FileSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 type FileSelectProps = {
   onSelection: (file: File) => void

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 interface LinkProps {
   children: string
   href: string

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default function Logo() {
   return (
     <svg

--- a/src/components/MadeWidthBadge.tsx
+++ b/src/components/MadeWidthBadge.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default function MadeWidthBadge() {
   return (
     <svg

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 interface ModalProps {
   children?: ReactNode

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 interface ProgressProps {
   percent: number
 }

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 type SliderProps = {
   label?: any
   value?: number

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import ReactDOM from 'react-dom'
 import './index.css'
 import App from './App'


### PR DESCRIPTION
1. call `configEnv()` only when `model` is not created, and reuse `capabilities`
    * `ort.env` only needs to be initialized once
    * reduce the number of calls to `getCapabilities()`
3. fix typo `capablilities` => `capabilities`
4. remove unnecessary variable declaration: `imgDom` & `markUrl`
5. remove all unused React imports
    no `import React` anymore in `*.tsx`
    ![image](https://github.com/lxfater/inpaint-web/assets/239585/96690023-0551-4c0c-b0ec-b32d66dbb9f6)
